### PR TITLE
feat: Make bot deployable on Render

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ announcements.
 Alternatively, [find me on telegram](https://t.me/jithumon)! (Keep all support questions in the support chat, where more people can help you.)
 
 
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/jithumon/tgbot)
+
+After deploying to Render, you will need to set the following environment variables in the Render dashboard:
+- `TOKEN`: Your bot token.
+- `OWNER_ID`: Your Telegram user ID.
+- `OWNER_USERNAME`: Your Telegram username.
+
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/jithumon/tgbot)<br>
 There is also a [tutorial video](https://youtu.be/W6CLKrehy6w) if you want any help on creating heroku clone.
 [![telegram badge](https://img.shields.io/badge/Support-Group-30302f?style=flat&logo=telegram)](https://telegram.dog/ELSupport)
@@ -70,7 +77,7 @@ class Development(Config):
     NO_LOAD = ['translation']
 ```
 
-If you can't have a config.py file (EG on heroku), it is also possible to use environment variables.
+If you can't have a config.py file (EG on heroku or render), it is also possible to use environment variables.
 The following env variables are supported:
  - `ENV`: Setting this to ANYTHING will enable env variables
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,28 @@
+services:
+  - type: worker
+    name: telegram-bot
+    env: python
+    plan: free
+    buildCommand: "pip install -r requirements.txt"
+    startCommand: "python3 -m tg_bot"
+    envVars:
+      - key: ENV
+        value: True
+      - key: TOKEN
+        sync: false
+      - key: OWNER_ID
+        sync: false
+      - key: OWNER_USERNAME
+        sync: false
+      - key: DATABASE_URL
+        fromDatabase:
+          name: telegram-bot-db
+          property: connectionString
+      - key: WEBHOOK
+        value: False
+
+databases:
+  - name: telegram-bot-db
+    plan: free
+    databaseName: telegram_bot
+    user: telegram_bot_user

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ psycopg2-binary==2.8.5
 python-telegram-bot==11.1.0
 requests==2.22.0
 SQLAlchemy==1.3.19
-feedparser
+feedparser==6.0.12


### PR DESCRIPTION
This change makes the Telegram bot deployable on the Render platform.

It introduces a `render.yaml` file that defines the necessary services for deployment, including a worker for the bot and a PostgreSQL database. The configuration is set up to use environment variables, with instructions in the README on how to set the required secrets.

The `requirements.txt` file has been updated to pin the version of `feedparser` to ensure reproducible builds.

The `README.md` has been updated with a "Deploy to Render" button and instructions for setting the necessary environment variables.